### PR TITLE
fix: tighten pyright gate, fix underlying bugs instead of suppressing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,9 +27,40 @@ test suite (excluding hardware tests).
 
 - One logical change per PR.
 - Branch from `main`, target `main`.
-- `main` is protected -- all changes go through PRs.
+- `main` is protected -- all changes go through PRs. Never push directly,
+  even for "trivial" fixes.
 - Include test coverage for new protocol commands or client behavior.
 - Update `AGENTS.md` if you change architecture or add new modules.
+
+## Quality Gates
+
+The gates defined in `pyproject.toml` (`ruff`, `pyright`, `complexipy`) and
+enforced by `make validate` are non-negotiable. When a gate fires:
+
+- **Fix the underlying bug.** If pyright reports an Optional access, add the
+  None-guard. If it reports a missing attribute, rename the call. The gates
+  exist to catch real defects -- silencing them defeats the purpose.
+- **Do not weaken the gate config** (downgrading errors to warnings,
+  lowering severity, broadening excludes) as a shortcut. Config changes
+  require an explicit justification in the PR description and are reviewed
+  with the same scrutiny as code changes.
+- **Targeted suppressions are a last resort.** A single `# noqa: <RULE>` or
+  `# type: ignore[<code>]` on one line is acceptable when the rule is
+  genuinely wrong for that site; it must be accompanied by a comment
+  explaining *why*. File-level or project-level suppressions should be
+  avoided.
+- **Do not introduce per-file excludes in `[tool.pyright]` or
+  `[tool.ruff.lint.per-file-ignores]`** without PR-body justification. The
+  existing `tools/*` C901 exemption is the only standing carve-out, because
+  debug scripts legitimately dispatch on many branches.
+
+## Dependencies
+
+- **Core runtime dependency** is `bleak` only. Anything else belongs in the
+  `[tools]` optional extra.
+- **Optional dependencies** (e.g. `aiohttp` in `wifi_client.py`) must be
+  imported lazily inside the function that needs them, not at module
+  top level, so a core install without `[tools]` never fails to import.
 
 ## Code Style
 

--- a/bentolab/ble_client.py
+++ b/bentolab/ble_client.py
@@ -127,10 +127,11 @@ class BentoLabBLE:
             return
 
         if parsed["type"] == "status":
-            self._last_status = parsed["data"]
+            status: StatusBroadcast = parsed["data"]
+            self._last_status = status
             for cb in self._status_callbacks:
                 try:
-                    cb(self._last_status)
+                    cb(status)
                 except Exception:
                     logger.exception("Status callback error")
         elif parsed["type"] != "continuation":
@@ -151,24 +152,29 @@ class BentoLabBLE:
     # Low-level send/receive
     # ------------------------------------------------------------------
 
-    def _check_connected(self) -> None:
+    def _require_client(self) -> BleakClient:
+        """Return the live BleakClient or raise if we're not connected."""
         if not self._client or not self._client.is_connected:
             raise BentoLabConnectionError("Not connected to Bento Lab")
+        return self._client
+
+    def _check_connected(self) -> None:
+        self._require_client()
 
     async def _send(self, cmd: str) -> None:
         """Send a command to the device via NUS RX."""
-        self._check_connected()
+        client = self._require_client()
         data = encode_command(cmd)
         try:
-            await self._client.write_gatt_char(NUS_RX_CHAR_UUID, data, response=False)
+            await client.write_gatt_char(NUS_RX_CHAR_UUID, data, response=False)
         except BleakError as e:
             raise BentoLabConnectionError(f"Write failed: {e}") from e
 
     async def _send_raw(self, data: bytes) -> None:
         """Send raw bytes to NUS RX."""
-        self._check_connected()
+        client = self._require_client()
         try:
-            await self._client.write_gatt_char(NUS_RX_CHAR_UUID, data, response=False)
+            await client.write_gatt_char(NUS_RX_CHAR_UUID, data, response=False)
         except BleakError as e:
             raise BentoLabConnectionError(f"Write failed: {e}") from e
 

--- a/bentolab/thermocycler.py
+++ b/bentolab/thermocycler.py
@@ -1,19 +1,39 @@
-"""Unified high-level interface for Bento Lab control."""
+"""Unified high-level interface for Bento Lab control.
+
+Wraps either :class:`BentoLabBLE` or :class:`BentoLabWiFi` behind a single
+:class:`BentoLab` facade. The facade speaks in high-level domain types
+(:class:`DeviceState`, :class:`PCRProfile`) and delegates to whichever
+transport was selected at construction.
+"""
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any, Union
 
 from .ble_client import BentoLabBLE
-from .models import DeviceState, PCRProfile
-from .wifi_client import BentoLabWiFi
+from .models import DeviceState, DeviceStatus, PCRProfile
+from .protocol import StatusBroadcast
+
+if TYPE_CHECKING:
+    from .wifi_client import BentoLabWiFi
+
+Transport = Union[BentoLabBLE, "BentoLabWiFi"]
+
+
+def _status_to_state(status: StatusBroadcast) -> DeviceState:
+    """Adapt a raw protocol :class:`StatusBroadcast` to the public :class:`DeviceState`."""
+    return DeviceState(
+        connected=True,
+        block_temperature=float(status.block_temperature),
+        lid_temperature=float(status.lid_temperature),
+        status=DeviceStatus.RUNNING if status.running else DeviceStatus.IDLE,
+    )
 
 
 class BentoLab:
     """Unified interface for Bento Lab control, regardless of connection type."""
 
-    def __init__(self, transport: BentoLabBLE | BentoLabWiFi):
+    def __init__(self, transport: Transport):
         self._transport = transport
 
     @classmethod
@@ -26,32 +46,43 @@ class BentoLab:
     @classmethod
     async def connect_wifi(cls, host: str | None = None) -> BentoLab:
         """Connect to a Bento Lab via Wi-Fi."""
+        from .wifi_client import BentoLabWiFi  # deferred: keeps aiohttp optional
+
         transport = BentoLabWiFi(host=host)
         await transport.connect()
         return cls(transport)
 
     async def get_state(self) -> DeviceState:
         """Get current device state."""
-        return await self._transport.get_state()
+        status = await self._transport.get_status()
+        return _status_to_state(status)
 
-    async def run_pcr(
-        self,
-        profile: PCRProfile,
-        progress_callback: Callable[[DeviceState], Any] | None = None,
-    ) -> None:
-        """Start a PCR run and optionally monitor progress."""
-        await self._transport.start_pcr(profile)
+    async def run_pcr(self, profile: PCRProfile, lid_temp: float = 110.0) -> None:
+        """Start a PCR run from a :class:`PCRProfile`.
+
+        Flattens the profile into the device's stage/cycle layout and
+        issues a single ``start_run`` call. Does not block until
+        completion — use :meth:`BentoLabBLE.run_profile` directly if you
+        want streaming progress updates.
+        """
+        stages, cycles = profile.to_stages_and_cycles()
+        await self._transport.start_run(
+            name=profile.name,
+            stages=stages,
+            cycles=cycles,
+            lid_temp=lid_temp,
+        )
 
     async def stop(self) -> None:
         """Stop the current run."""
-        await self._transport.stop_pcr()
+        await self._transport.stop_run()
 
     async def disconnect(self) -> None:
         """Disconnect from the device."""
         await self._transport.disconnect()
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> BentoLab:
         return self
 
-    async def __aexit__(self, *exc):
+    async def __aexit__(self, *exc: Any) -> None:
         await self.disconnect()

--- a/bentolab/wifi_client.py
+++ b/bentolab/wifi_client.py
@@ -1,14 +1,24 @@
-"""Wi-Fi/HTTP client for Bento Lab V1.31."""
+"""Wi-Fi/HTTP client for Bento Lab V1.31.
+
+Stub. The Wi-Fi protocol has not been reverse-engineered yet; every
+method raises :class:`NotImplementedError`. The public surface is kept
+aligned with :class:`bentolab.ble_client.BentoLabBLE` so a future
+implementation can slot in behind the shared
+:class:`bentolab.thermocycler.BentoLab` wrapper without an API break.
+"""
 
 from __future__ import annotations
 
-import aiohttp
+from typing import TYPE_CHECKING, Any
 
-from .models import DeviceState, PCRProfile
+from .protocol import StatusBroadcast
+
+if TYPE_CHECKING:
+    import aiohttp
 
 
 class BentoLabWiFi:
-    """HTTP/WebSocket client for controlling a Bento Lab V1.31 unit."""
+    """HTTP/WebSocket client stub for Bento Lab V1.31."""
 
     def __init__(self, host: str | None = None, port: int = 80):
         self.host = host
@@ -21,6 +31,8 @@ class BentoLabWiFi:
 
     async def connect(self, host: str | None = None) -> None:
         """Connect to the Bento Lab Wi-Fi unit."""
+        import aiohttp  # local import: keeps aiohttp optional for the core install
+
         self.host = host or self.host
         if not self.host:
             self.host = await self.discover()
@@ -32,25 +44,32 @@ class BentoLabWiFi:
             await self._session.close()
             self._session = None
 
-    async def get_state(self) -> DeviceState:
-        """Read current device state."""
+    async def get_status(self) -> StatusBroadcast:
+        """Read current device status."""
         raise NotImplementedError("Protocol not yet reverse-engineered")
 
     async def get_firmware_version(self) -> str:
         """Query firmware version."""
         raise NotImplementedError("Protocol not yet reverse-engineered")
 
-    async def start_pcr(self, profile: PCRProfile) -> None:
+    async def start_run(
+        self,
+        name: str = "Python Run",
+        stages: list[tuple[float, int]] | None = None,
+        cycles: list[tuple[int, int, int]] | None = None,
+        lid_temp: float = 110.0,
+        slot: int = 0,
+    ) -> None:
         """Start a PCR run."""
         raise NotImplementedError("Protocol not yet reverse-engineered")
 
-    async def stop_pcr(self) -> None:
+    async def stop_run(self) -> None:
         """Stop the current PCR run."""
         raise NotImplementedError("Protocol not yet reverse-engineered")
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> BentoLabWiFi:
         await self.connect()
         return self
 
-    async def __aexit__(self, *exc):
+    async def __aexit__(self, *exc: Any) -> None:
         await self.disconnect()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,11 +54,7 @@ exclude = [
     "**/__pycache__",
     "**/node_modules",
     "**/.*",
-    "bentolab/thermocycler.py",
-    "bentolab/wifi_client.py",
 ]
-reportOptionalMemberAccess = "warning"
-reportArgumentType = "warning"
 
 [build-system]
 requires = ["setuptools>=68.0"]

--- a/tests/test_thermocycler.py
+++ b/tests/test_thermocycler.py
@@ -1,0 +1,112 @@
+"""Tests for the high-level BentoLab facade in thermocycler.py."""
+
+import pytest
+
+from bentolab.models import DeviceStatus, PCRProfile
+from bentolab.protocol import StatusBroadcast
+from bentolab.thermocycler import BentoLab, _status_to_state
+
+
+def test_status_to_state_adapter_idle():
+    status = StatusBroadcast(
+        running=0,
+        field2=0,
+        field3=0,
+        field4=0,
+        block_temperature=24,
+        lid_temperature=23,
+        field7=0,
+    )
+    state = _status_to_state(status)
+    assert state.connected is True
+    assert state.status == DeviceStatus.IDLE
+    assert state.block_temperature == 24.0
+    assert state.lid_temperature == 23.0
+
+
+def test_status_to_state_adapter_running():
+    status = StatusBroadcast(
+        running=1,
+        field2=0,
+        field3=0,
+        field4=0,
+        block_temperature=95,
+        lid_temperature=110,
+        field7=0,
+    )
+    state = _status_to_state(status)
+    assert state.status == DeviceStatus.RUNNING
+
+
+class _FakeTransport:
+    """Minimal stand-in that records calls and returns canned status."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+        self._status = StatusBroadcast(1, 0, 0, 0, 72, 110, 0)
+
+    async def get_status(self) -> StatusBroadcast:
+        self.calls.append(("get_status", {}))
+        return self._status
+
+    async def start_run(self, **kwargs) -> None:
+        self.calls.append(("start_run", kwargs))
+
+    async def stop_run(self) -> None:
+        self.calls.append(("stop_run", {}))
+
+    async def disconnect(self) -> None:
+        self.calls.append(("disconnect", {}))
+
+
+@pytest.fixture
+def fake_lab():
+    transport = _FakeTransport()
+    return BentoLab(transport), transport  # type: ignore[arg-type]
+
+
+async def test_get_state_calls_transport_get_status(fake_lab):
+    lab, transport = fake_lab
+    state = await lab.get_state()
+    assert [c[0] for c in transport.calls] == ["get_status"]
+    assert state.status == DeviceStatus.RUNNING
+    assert state.block_temperature == 72.0
+
+
+async def test_run_pcr_flattens_profile_and_calls_start_run(fake_lab):
+    lab, transport = fake_lab
+    profile = PCRProfile.simple(
+        name="Facade Test",
+        num_cycles=15,
+        initial_denaturation=(95.0, 120),
+        denaturation=(95.0, 20),
+        annealing=(60.0, 20),
+        extension=(72.0, 40),
+        final_extension=(72.0, 180),
+    )
+    await lab.run_pcr(profile, lid_temp=108.0)
+    assert len(transport.calls) == 1
+    kind, kwargs = transport.calls[0]
+    assert kind == "start_run"
+    assert kwargs["name"] == "Facade Test"
+    assert kwargs["stages"] == [
+        (95.0, 120),
+        (95.0, 20),
+        (60.0, 20),
+        (72.0, 40),
+        (72.0, 180),
+    ]
+    assert kwargs["cycles"] == [(4, 2, 15)]
+    assert kwargs["lid_temp"] == 108.0
+
+
+async def test_stop_calls_transport_stop_run(fake_lab):
+    lab, transport = fake_lab
+    await lab.stop()
+    assert transport.calls == [("stop_run", {})]
+
+
+async def test_disconnect_calls_transport_disconnect(fake_lab):
+    lab, transport = fake_lab
+    await lab.disconnect()
+    assert transport.calls == [("disconnect", {})]


### PR DESCRIPTION
## Summary

The governance PR (#1) merged with pyright suppressions layered in so
`make validate` would pass in one sitting. Those suppressions were
masking real defects. This PR removes every suppression and fixes the
root causes the gate was flagging.

## What was masked

Prior to this PR, `pyproject.toml` contained:

```toml
[tool.pyright]
exclude = [..., "bentolab/thermocycler.py", "bentolab/wifi_client.py"]
reportOptionalMemberAccess = "warning"
reportArgumentType = "warning"
```

Behind those, three real bugs were hiding:

1. **`thermocycler.BentoLab` was broken at runtime.** It called
   `get_state` / `start_pcr` / `stop_pcr` on the transport, but those
   methods only existed on the `BentoLabWiFi` stub. The BLE transport
   uses `get_status` / `start_run` / `stop_run`. Any user doing
   `await BentoLab.connect_ble(...).get_state()` would get an
   `AttributeError`.
2. **`ble_client._send` / `_send_raw` could not be narrowed by
   pyright.** The `_check_connected()` guard was a separate call, so
   pyright could not prove `self._client` was non-None at the
   `write_gatt_char` site. The `reportOptionalMemberAccess = warning`
   downgrade was hiding the narrowing gap.
3. **`ble_client._on_notify` passed `self._last_status` to callbacks
   without a narrowed local.** The assignment read from an `Unknown`
   dict value, so the callback argument type was
   `Unknown | StatusBroadcast | None`. The `reportArgumentType = warning`
   downgrade was hiding this.

## Fixes

- **Unify transport API.** Renamed `BentoLabWiFi.get_state/start_pcr/
  stop_pcr` to `get_status/start_run/stop_run` so both transports share
  one surface area. The facade no longer has to branch on transport.
- **Facade state adapter.** `thermocycler._status_to_state` converts
  the raw protocol `StatusBroadcast` to the public `DeviceState`
  inside `BentoLab.get_state`, keeping the high-level API clean.
- **Facade profile flattening.** `BentoLab.run_pcr(profile)` flattens
  the `PCRProfile` into `(stages, cycles)` and issues a single
  `start_run` call, matching what the BLE transport accepts.
- **Narrowed client access.** Extracted `BentoLabBLE._require_client()`
  that returns the live `BleakClient` or raises. `_send` and
  `_send_raw` now bind a local `client` variable, which pyright can
  narrow through.
- **Typed local for status broadcasts.** `_on_notify` binds
  `status: StatusBroadcast = parsed["data"]` before invoking callbacks,
  eliminating the Unknown-from-dict warning.
- **Lazy-imported optional deps.** `wifi_client.py` imports `aiohttp`
  inside `connect()` (with `TYPE_CHECKING` for static analysis), and
  `thermocycler.connect_wifi` lazy-imports `BentoLabWiFi`. A core
  install (bleak only) can now `import bentolab.thermocycler` without
  `aiohttp` present.

## Governance

- **`pyproject.toml` pyright config** drops the per-file excludes and
  the severity downgrades. The gate is back to full strength: basic
  mode, zero warnings, zero errors.
- **`CONTRIBUTING.md` gains a "Quality Gates" section** documenting the
  rule this PR retroactively enforces: *fix the bug, don't weaken the
  gate*. It also documents the lazy-import rule for optional
  dependencies, which came up organically from the `aiohttp` fix.

## Tests

- New `tests/test_thermocycler.py` with 6 tests covering the
  status->state adapter and the facade's delegation of `get_state`,
  `run_pcr`, `stop`, and `disconnect` to the transport under the
  expected method names.
- Total: **54 passing** (was 48 before this PR).

## Validation

`make validate` locally:

```
ruff format --check ............. OK
ruff check ...................... OK
pyright ......................... 0 errors, 0 warnings, 0 informations
complexipy ...................... OK
pytest -m "not hardware" ........ 54 passed in 0.04s
```

## Test plan

- [ ] CI green on `ubuntu-latest` x `{3.11, 3.12, 3.13}`
- [ ] `make validate` passes locally
- [ ] Manual smoke test with a physical Bento Lab in range -- deferred,
      no hardware currently available

## Note on scope

This PR bundles three things that qte77's CONTRIBUTING.md would
normally keep separate (code fixes, test additions, doc update), but
they are all manifestations of one logical change: *the gate is
load-bearing, and here is the retroactive proof plus the rule going
forward*. Keeping them together makes the lesson legible; splitting
would obscure the why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)