### PR TITLE
chore: add CodeQL workflow, dependabot config, and status badges

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,26 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "27 11 * * 0"
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: python
+      - uses: github/codeql-action/autobuild@v3
+      - uses: github/codeql-action/analyze@v3

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # bentolab
 
+[![CodeFactor](https://www.codefactor.io/repository/github/lambda-biolab/bentolab/badge)](https://www.codefactor.io/repository/github/lambda-biolab/bentolab)
+[![CodeQL](https://github.com/Lambda-Biolab/bentolab/actions/workflows/codeql.yml/badge.svg)](https://github.com/Lambda-Biolab/bentolab/actions/workflows/codeql.yml)
+[![Dependabot](https://img.shields.io/badge/dependabot-enabled-blue?logo=dependabot)](https://github.com/Lambda-Biolab/bentolab/network/updates)
+
 Python control library for [Bento Lab](https://bento.bio/) PCR workstations
 (Bento Bioworks, London). Communicates over Bluetooth LE using the Nordic UART
 Service protocol, reverse-engineered from the official Bento Bio app.


### PR DESCRIPTION
## Summary
- Add CodeQL security scanning workflow
- Add Dependabot config for pip + github-actions
- Add CodeFactor, CodeQL, and Dependabot status badges to README

## Test plan
- [ ] Verify CodeQL workflow runs on merge
- [ ] Verify Dependabot opens PRs within a week
- [ ] Verify badges render correctly

Generated with Claude <noreply@anthropic.com>