### PR TITLE
fix(ble): require sustained idle or progress>=99 to end run_pcr

### DIFF
--- a/bentolab/ble_client.py
+++ b/bentolab/ble_client.py
@@ -452,12 +452,20 @@ class BentoLabBLE:
         cycles: list[tuple[int, int, int]] | None = None,
         lid_temp: float = 110.0,
         poll_interval: float = 5.0,
+        startup_grace_seconds: float = 120.0,
+        completion_confirmations: int = 3,
     ) -> AsyncIterator[PCRRunState]:
         """Run a PCR program and yield status updates until completion.
 
         This is the high-level API for running PCR with progress tracking.
         Yields PCRRunState objects at each poll interval until the run
         completes or is stopped.
+
+        Termination requires *either* progress >= 99% OR
+        ``completion_confirmations`` consecutive ``running=False`` polls
+        after ``startup_grace_seconds`` has elapsed. This avoids exiting
+        on transient ``running=False`` flips that the device emits during
+        the lid-heat / pre-cycle ramp before stage 1 reaches setpoint.
 
         Usage::
 
@@ -473,10 +481,16 @@ class BentoLabBLE:
             cycles: List of (from_stage, to_stage, num_cycles).
             lid_temp: Lid temperature in Celsius.
             poll_interval: Seconds between status polls.
+            startup_grace_seconds: Ignore ``running=False`` for this long
+                after starting, to ride out the lid-heat ramp.
+            completion_confirmations: Number of consecutive ``running=False``
+                polls (after the grace period) required to declare done.
         """
         await self.start_run(name=name, stages=stages, cycles=cycles, lid_temp=lid_temp)
 
         elapsed = 0.0
+        consecutive_not_running = 0
+        peak_progress = 0
         while True:
             await asyncio.sleep(poll_interval)
             elapsed += poll_interval
@@ -490,6 +504,8 @@ class BentoLabBLE:
                 running = bool(status.running)
                 progress = 0
 
+            peak_progress = max(peak_progress, progress)
+
             state = PCRRunState(
                 running=running,
                 progress=progress,
@@ -499,8 +515,24 @@ class BentoLabBLE:
             )
             yield state
 
-            if not running:
-                logger.info("PCR run completed after %.0fs", elapsed)
+            if running:
+                consecutive_not_running = 0
+                continue
+
+            consecutive_not_running += 1
+
+            if peak_progress >= 99:
+                logger.info("PCR run completed after %.0fs (progress=%d)", elapsed, progress)
+                break
+            if (
+                elapsed >= startup_grace_seconds
+                and consecutive_not_running >= completion_confirmations
+            ):
+                logger.info(
+                    "PCR run completed after %.0fs (%d consecutive idle polls)",
+                    elapsed,
+                    consecutive_not_running,
+                )
                 break
 
     # ------------------------------------------------------------------

--- a/tests/test_ble_client.py
+++ b/tests/test_ble_client.py
@@ -10,6 +10,7 @@ from bentolab.ble_client import (
     ProfileData,
 )
 from bentolab.models import PCRProfile
+from bentolab.protocol import RunStatus, StatusBroadcast
 
 # --- Fixtures ---
 
@@ -184,3 +185,125 @@ async def test_run_profile_flattens_and_forwards(lab):
     assert captured["cycles"] == [(4, 2, 12)]
     assert captured["lid_temp"] == 108.0
     assert captured["poll_interval"] == 1.5
+
+
+# --- run_pcr termination logic ---
+
+
+def _status(block: int = 25, lid: int = 110, running: int = 1) -> StatusBroadcast:
+    return StatusBroadcast(
+        running=running,
+        field2=0,
+        field3=0,
+        field4=0,
+        block_temperature=block,
+        lid_temperature=lid,
+        field7=0,
+    )
+
+
+def _patch_run_pcr_dependencies(
+    lab: BentoLabBLE,
+    *,
+    run_status_seq: list[RunStatus],
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[PCRRunState]:
+    """Wire up start_run/get_status/poll_run_status/sleep for run_pcr tests."""
+
+    async def fake_start_run(**_kwargs):
+        return None
+
+    async def fake_get_status():
+        return _status()
+
+    seq_iter = iter(run_status_seq)
+
+    async def fake_poll_run_status():
+        try:
+            return next(seq_iter)
+        except StopIteration:
+            return RunStatus(running=False, checksum=0, progress=100)
+
+    async def fake_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr(lab, "start_run", fake_start_run)
+    monkeypatch.setattr(lab, "get_status", fake_get_status)
+    monkeypatch.setattr(lab, "poll_run_status", fake_poll_run_status)
+    monkeypatch.setattr("bentolab.ble_client.asyncio.sleep", fake_sleep)
+    return []
+
+
+async def test_run_pcr_ignores_transient_not_running_during_grace(lab, monkeypatch):
+    """A single early running=False (lid-heat ramp) must not end the run."""
+    run_status_seq = [
+        RunStatus(running=True, checksum=0, progress=10),
+        RunStatus(running=True, checksum=0, progress=23),
+        RunStatus(running=True, checksum=0, progress=36),
+        RunStatus(running=True, checksum=0, progress=50),
+        RunStatus(running=False, checksum=0, progress=63),  # transient flip
+        RunStatus(running=True, checksum=0, progress=70),
+        RunStatus(running=True, checksum=0, progress=99),
+        RunStatus(running=False, checksum=0, progress=100),  # real completion
+    ]
+    _patch_run_pcr_dependencies(lab, run_status_seq=run_status_seq, monkeypatch=monkeypatch)
+
+    states = [
+        s
+        async for s in lab.run_pcr(
+            poll_interval=10.0,
+            startup_grace_seconds=120.0,
+            completion_confirmations=3,
+        )
+    ]
+
+    # Must consume past the transient (index 4) and reach completion at index 7.
+    assert len(states) == 8
+    assert states[-1].progress == 100
+    assert not states[-1].running
+
+
+async def test_run_pcr_completes_on_progress_99(lab, monkeypatch):
+    """Reaching peak progress >=99% terminates immediately on next idle."""
+    run_status_seq = [
+        RunStatus(running=True, checksum=0, progress=50),
+        RunStatus(running=True, checksum=0, progress=99),
+        RunStatus(running=False, checksum=0, progress=100),
+    ]
+    _patch_run_pcr_dependencies(lab, run_status_seq=run_status_seq, monkeypatch=monkeypatch)
+
+    states = [
+        s
+        async for s in lab.run_pcr(
+            poll_interval=10.0,
+            startup_grace_seconds=600.0,  # well past elapsed
+            completion_confirmations=5,
+        )
+    ]
+
+    assert len(states) == 3
+    assert states[-1].progress == 100
+
+
+async def test_run_pcr_requires_consecutive_idle_after_grace(lab, monkeypatch):
+    """After grace, N consecutive idle polls (without progress=99) terminate."""
+    run_status_seq = [
+        RunStatus(running=True, checksum=0, progress=20),
+        RunStatus(running=True, checksum=0, progress=40),
+        RunStatus(running=False, checksum=0, progress=50),  # past grace
+        RunStatus(running=False, checksum=0, progress=50),
+        RunStatus(running=False, checksum=0, progress=50),  # 3rd consecutive
+    ]
+    _patch_run_pcr_dependencies(lab, run_status_seq=run_status_seq, monkeypatch=monkeypatch)
+
+    states = [
+        s
+        async for s in lab.run_pcr(
+            poll_interval=10.0,
+            startup_grace_seconds=20.0,  # grace ends after 2 polls
+            completion_confirmations=3,
+        )
+    ]
+
+    assert len(states) == 5
+    assert not states[-1].running


### PR DESCRIPTION
## Summary

- Fixes #11. `run_pcr` no longer exits on the first transient `running=False` emitted during the lid-heat / pre-cycle ramp.
- Termination now requires *either* peak progress >=99% on an idle poll, *or* `completion_confirmations` (default 3) consecutive idle polls *after* `startup_grace_seconds` (default 120 s).
- Both thresholds are exposed as kwargs on `run_pcr` (and pass through `run_profile`).

## Background

Observed on a real ~70-min and ~121-min run (S4 6.9 kb and HF-Pgl3-EGFP-Puro-linear). The device kept running correctly; only the BLE poller bailed at 50 s when `pe` returned `running=False progress=63%` mid-ramp, which closed the async iterator and triggered `__aexit__`-driven disconnect. Operator lost live monitoring even though the program completed.

## Changes

- \`bentolab/ble_client.py\`: track `peak_progress` and `consecutive_not_running`, gate termination on grace + sustained idle or progress threshold.
- \`tests/test_ble_client.py\`: 3 new tests
  - transient idle during grace is ignored, run continues to real completion
  - progress >= 99% terminates immediately on next idle poll
  - after grace, N consecutive idle polls terminate even without progress=99

## Test plan

- [x] `make validate` — ruff format, ruff check, pyright (0 errors), 57 tests pass
- [ ] Verify on next real run that the iterator stays alive past lid-heat ramp
- [ ] Confirm graceful termination on actual completion (not just timeout)

Closes #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)