### PR TITLE
chore: relicense MIT -> Apache 2.0 with NOTICE and trademark posture

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2026 Lambda Biolab
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may accept and charge a
+      fee for acceptance of support, warranty, indemnity, or other liability
+      obligations and/or rights consistent with this License. However, in
+      accepting such obligations, You may act only on Your own behalf
+      and on Your sole responsibility, not on behalf of any other
+      Contributor, and only if You agree to indemnify, defend, and hold
+      each Contributor harmless for any liability incurred by, or claims
+      asserted against, such Contributor by reason of your accepting any
+      such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Lambda Biolab
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,20 @@
+bentolab
+Copyright 2026 Lambda Biolab
+
+This product includes software developed by Lambda Biolab and the
+bentolab contributors (https://github.com/Lambda-Biolab/bentolab).
+
+Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+This is an UNOFFICIAL, community-maintained library. It is not
+affiliated with, endorsed by, or supported by Bento Bioworks Ltd.,
+the manufacturer of the Bento Lab PCR workstation. "Bento Lab" and
+"Bento Bioworks" are trademarks of their respective owners; no
+trademark license is granted by this distribution.
+
+The Bluetooth Low Energy protocol used by this library was decoded
+through black-box observation of HCI snoop captures and Android APK
+decompilation, in line with the interoperability exceptions in
+17 U.S.C. § 1201(f) (DMCA) and Article 6 of EU Software Directive
+2009/24/EC. No firmware, copyrighted source code, or proprietary
+documentation from Bento Bioworks is redistributed in this work.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 [![CodeFactor](https://www.codefactor.io/repository/github/lambda-biolab/bentolab/badge)](https://www.codefactor.io/repository/github/lambda-biolab/bentolab)
 [![CodeQL](https://github.com/Lambda-Biolab/bentolab/actions/workflows/codeql.yml/badge.svg)](https://github.com/Lambda-Biolab/bentolab/actions/workflows/codeql.yml)
 [![Dependabot](https://img.shields.io/badge/dependabot-enabled-blue?logo=dependabot)](https://github.com/Lambda-Biolab/bentolab/network/updates)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+
+> ⚠️ **Unofficial.** This is a community-maintained library. It is not
+> affiliated with, endorsed by, or supported by Bento Bioworks Ltd. See
+> [Disclaimer](#disclaimer) and [`NOTICE`](NOTICE).
 
 Python control library for [Bento Lab](https://bento.bio/) PCR workstations
 (Bento Bioworks, London). Communicates over Bluetooth LE using the Nordic UART
@@ -128,7 +133,8 @@ python tools/ble_commander.py
 
 ## License
 
-[MIT](LICENSE).
+[Apache License 2.0](LICENSE) — see also [NOTICE](NOTICE) for attribution and
+the trademark / interoperability disclaimers that ship with every redistribution.
 
 ## Disclaimer
 

--- a/docs/LICENSING_ASSESSMENT.md
+++ b/docs/LICENSING_ASSESSMENT.md
@@ -34,7 +34,12 @@ analysis — no access controls are circumvented.
    — https://github.com/newren/git-filter-repo
    — https://rtyley.github.io/bfg-repo-cleaner/
 
-2. **Add a LICENSE file** — currently missing entirely. Recommended: MIT or
+2. ~~**Add a LICENSE file** — currently missing entirely. Recommended: MIT or~~
+   **DONE.** Apache License 2.0 with a `NOTICE` file. See `LICENSE` and `NOTICE`
+   at the repo root. Apache was preferred over MIT for the explicit patent
+   grant, retaliation clause, change-tracking requirement, and trademark scope
+   (Section 6) — all of which matter for a reverse-engineered library that
+   names third-party hardware. Original recommendation noted: MIT or
    Apache-2.0 for library code.
 
 ### Recommended

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,8 @@ name = "bentolab"
 version = "0.1.0"
 description = "Python control library for Bento Lab PCR workstations"
 requires-python = ">=3.11"
+license = "Apache-2.0"
+license-files = ["LICENSE", "NOTICE"]
 dependencies = [
     "bleak>=0.22.0",
     "platformdirs>=4.0",


### PR DESCRIPTION
## Summary

Relicenses the project from MIT to Apache 2.0, adds a \`NOTICE\` file, and surfaces the non-affiliation disclaimer at the top of the README.

## Why Apache over MIT

For a reverse-engineered hardware-control library that names a third-party brand, Apache 2.0 is a strict upgrade:

| Concern | MIT | Apache 2.0 |
|---|---|---|
| Permissive (closed-source forks ok) | ✓ | ✓ |
| Explicit patent grant from contributors | ✗ | ✓ |
| Patent retaliation termination | ✗ | ✓ |
| Forks must mark modifications | ✗ | ✓ |
| \`NOTICE\` file mechanism for attribution | ✗ | ✓ |
| Trademark scope clarified (§6) | ✗ | ✓ |

Apache adds a real patent grant and a documented chain-of-custody for changes, while remaining permissive enough that downstream commercial integration sees zero new friction. Trademark scoping (§6) matters for this project because "Bento Lab" is Bento Bioworks' trademark, not ours — Apache makes the line between code license and trademark license explicit at the license layer, not just in a README disclaimer.

## Changes

- **\`LICENSE\`** — full Apache 2.0 boilerplate, copyright "2026 Lambda Biolab".
- **\`NOTICE\`** — attribution + non-affiliation + trademark + interoperability legal basis statement (DMCA §1201(f) and EU Software Directive 2009/24/EC Article 6). Apache §4(d) requires this file to ship with every redistribution.
- **\`pyproject.toml\`** — SPDX \`license = "Apache-2.0"\` and \`license-files = ["LICENSE", "NOTICE"]\` so both ship in the wheel and sdist.
- **\`README.md\`** — license section now points at \`LICENSE\` + \`NOTICE\`; added an Apache-2.0 badge and a top-of-readme **"Unofficial"** callout so the non-affiliation disclaimer is the first thing a reader sees, not buried at the bottom.
- **\`docs/LICENSING_ASSESSMENT.md\`** — original "missing license" item marked done with the rationale for picking Apache over MIT.

## Non-affiliation coverage (post-merge)

Three layers, redundant on purpose:

1. **\`NOTICE\` file** — load-bearing per Apache §4(d), travels with every redistribution.
2. **\`LICENSE\` §6** — formal trademark scope.
3. **\`README.md\`** — top-of-page callout banner + existing Disclaimer section near the bottom.

## Test plan

- [x] \`make validate\` (ruff format/check, pyright, complexipy, pytest 92/92)
- [ ] After merge: confirm PyPI metadata picks up Apache-2.0 SPDX (currently no PyPI release).
- [ ] After merge: confirm GitHub repo "License" detector flips to Apache 2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)