### PR TITLE
feat(ble): keep-alive task to prevent firmware-side idle disconnects

### DIFF
--- a/bentolab/ble_client.py
+++ b/bentolab/ble_client.py
@@ -102,10 +102,16 @@ class BentoLabBLE:
         address: str | None = None,
         name_filter: str = r"(?i)bento",
         auto_reconnect: bool = True,
+        keep_alive_seconds: float = 30.0,
     ):
         self.address = address
         self.name_filter = re.compile(name_filter)
         self.auto_reconnect = auto_reconnect
+        # Bento firmware appears to drop the BLE link after tens of
+        # seconds of application-layer silence even though the device is
+        # happily broadcasting status. Re-issuing the handshake on a
+        # timer keeps the connection up. Set 0 to disable.
+        self.keep_alive_seconds = keep_alive_seconds
         self._client: BleakClient | None = None
         self._rx_buffer: list[dict] = []
         self._rx_event = asyncio.Event()
@@ -113,6 +119,7 @@ class BentoLabBLE:
         self._disconnect_callbacks: list[Callable[[], Any]] = []
         self._last_status: StatusBroadcast | None = None
         self._connected_address: str | None = None
+        self._keep_alive_task: asyncio.Task[None] | None = None
 
     # ------------------------------------------------------------------
     # Notification handler
@@ -142,6 +149,9 @@ class BentoLabBLE:
         """Handle unexpected BLE disconnection."""
         logger.warning("BLE connection lost")
         self._client = None
+        if self._keep_alive_task is not None:
+            self._keep_alive_task.cancel()
+            self._keep_alive_task = None
         for cb in self._disconnect_callbacks:
             try:
                 cb()
@@ -250,6 +260,37 @@ class BentoLabBLE:
         # Send handshake and wait for first status
         await self._send("Xa")
         await asyncio.sleep(0.5)
+        self._start_keep_alive()
+
+    def _start_keep_alive(self) -> None:
+        if self.keep_alive_seconds <= 0:
+            return
+        if self._keep_alive_task is not None and not self._keep_alive_task.done():
+            return
+        self._keep_alive_task = asyncio.create_task(
+            self._keep_alive_loop(), name="bentolab-keep-alive"
+        )
+
+    async def _keep_alive_loop(self) -> None:
+        """Periodically poke the device so the firmware keeps the link.
+
+        Sends ``Xa`` (handshake / device-info request) on a fixed
+        cadence. The response goes through the same notification path
+        as any other reply; nothing here waits on it. If the write
+        fails the connection is already gone, so we just exit and let
+        the disconnect callback fire.
+        """
+        try:
+            while True:
+                await asyncio.sleep(self.keep_alive_seconds)
+                if not self.is_connected:
+                    return
+                try:
+                    await self._send("Xa")
+                except BentoLabConnectionError:
+                    return
+        except asyncio.CancelledError:
+            return
 
     async def reconnect(self) -> None:
         """Reconnect to the last known device."""
@@ -260,6 +301,11 @@ class BentoLabBLE:
 
     async def disconnect(self) -> None:
         """Disconnect from the device."""
+        if self._keep_alive_task is not None:
+            self._keep_alive_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self._keep_alive_task
+            self._keep_alive_task = None
         if self._client and self._client.is_connected:
             with contextlib.suppress(BleakError):
                 await self._client.stop_notify(NUS_TX_CHAR_UUID)

--- a/tests/test_keep_alive.py
+++ b/tests/test_keep_alive.py
@@ -1,0 +1,80 @@
+"""Keep-alive task tests for BentoLabBLE.
+
+We don't go through `connect` (that needs bleak machinery); instead we
+exercise `_start_keep_alive` and `_keep_alive_loop` directly with a
+patched `_send`, the way the real connect path would.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from bentolab.ble_client import BentoLabBLE, BentoLabConnectionError
+
+
+class _FakeClient:
+    is_connected = True
+
+
+@pytest.fixture
+def lab(monkeypatch: pytest.MonkeyPatch) -> BentoLabBLE:
+    inst = BentoLabBLE(keep_alive_seconds=0.05)
+    inst._client = _FakeClient()  # type: ignore[assignment]
+
+    sent: list[str] = []
+
+    async def fake_send(cmd: str) -> None:
+        sent.append(cmd)
+
+    monkeypatch.setattr(inst, "_send", fake_send)
+    inst._sent = sent  # type: ignore[attr-defined]
+    return inst
+
+
+async def test_keep_alive_emits_xa_periodically(lab: BentoLabBLE) -> None:
+    lab._start_keep_alive()
+    try:
+        await asyncio.sleep(0.18)  # enough for ~3 ticks at 50 ms cadence
+    finally:
+        if lab._keep_alive_task:
+            lab._keep_alive_task.cancel()
+    sent: list[str] = lab._sent  # type: ignore[attr-defined]
+    assert sent.count("Xa") >= 2
+    assert all(c == "Xa" for c in sent)
+
+
+async def test_keep_alive_stops_when_disconnected(lab: BentoLabBLE) -> None:
+    lab._start_keep_alive()
+    await asyncio.sleep(0.06)
+    lab._client = None  # simulate disconnect
+    await asyncio.sleep(0.1)
+    # Task should have noticed and exited cleanly.
+    assert lab._keep_alive_task is not None
+    assert lab._keep_alive_task.done()
+
+
+async def test_keep_alive_swallows_send_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    inst = BentoLabBLE(keep_alive_seconds=0.05)
+    inst._client = _FakeClient()  # type: ignore[assignment]
+
+    async def boom(_cmd: str) -> None:
+        raise BentoLabConnectionError("link gone")
+
+    monkeypatch.setattr(inst, "_send", boom)
+    inst._start_keep_alive()
+    await asyncio.sleep(0.1)
+    assert inst._keep_alive_task is not None
+    assert inst._keep_alive_task.done()
+
+
+def test_zero_disables_keep_alive() -> None:
+    inst = BentoLabBLE(keep_alive_seconds=0.0)
+    inst._start_keep_alive()
+    assert inst._keep_alive_task is None
+
+
+# Suppress unused-import lint
+_ = Any


### PR DESCRIPTION
## Summary

Closes #17. Adds an application-layer keep-alive task to \`BentoLabBLE\` that re-issues the \`Xa\` handshake every 30 seconds while connected. Heuristic fix for the BLE link drop the device exhibits after tens of seconds of central-side silence.

## Why

The Bento Lab firmware appears to drop the BLE connection if the central (us) doesn't send any GATT writes within ~tens of seconds, even though the device is happily broadcasting \`bb;\` status to us. The official Android app stays connected for multi-hour runs, so it must be doing something on a timer. None of the decoded commands look like a ping; \`Xa\` (handshake) is idempotent and returns a benign "device info" reply, so re-issuing it is the safest bet without a fresh HCI snoop.

See #17 for the full investigation, open questions, and suggested follow-up to confirm the exact timeout and the actual command the official app uses.

## Implementation

- \`BentoLabBLE.__init__\` accepts \`keep_alive_seconds\` (default 30, 0 disables).
- \`_start_keep_alive()\` spawns an asyncio task on every successful connect.
- \`_keep_alive_loop()\` sleeps, verifies \`is_connected\`, sends \`Xa\`, repeats. Send errors short-circuit cleanly.
- \`disconnect()\` and the unexpected-disconnect handler both cancel and clear the task so we never leak workers.

The reply to \`Xa\` lands in the same rx buffer as any other notification and is consumed by the next \`_collect_responses\` call (or aged out of the buffer harmlessly). No flow-control change to the run loop or status callbacks.

## Tests

\`tests/test_keep_alive.py\` — 4 new:

1. Emits \`Xa\` at the configured cadence.
2. Stops when the client goes away.
3. Swallows \`BentoLabConnectionError\` from \`_send\` and exits cleanly.
4. \`keep_alive_seconds=0\` disables the task entirely (no background worker).

\`make validate\` green: ruff, pyright 0/0/0, complexipy, **96 tests passing**.

## Test plan

- [x] \`make validate\`
- [ ] Real hardware: open a TUI session, leave it idle for 10+ minutes, confirm no unexpected \`BLE connection lost\` messages appear.
- [ ] Real hardware: kick off a PCR run via \`bentolab run --no-tail\`, then \`bentolab monitor --duration 600\` for 10 minutes, watch for drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)