### PR TITLE
chore(ruff): enable bandit-equivalent S rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,13 +46,14 @@ target-version = "py311"
 line-length = 100
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "UP", "B", "SIM", "C90"]
+select = ["E", "F", "I", "UP", "B", "S", "SIM", "C90"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10
 
 [tool.ruff.lint.per-file-ignores]
-"tools/*" = ["C901"]
+"tools/*" = ["C901", "S603", "S607"]  # complexity (TODO: refactor 9 fns), intentional subprocess
+"tests/*" = ["S101"]  # pytest requires assert
 
 [tool.pyright]
 pythonVersion = "3.11"


### PR DESCRIPTION
Enable Ruff's `S` rule set (Bandit-equivalent security checks) to bring this repo into line with the org-wide convention.

## Changes
- Added `S` to `[tool.ruff.lint] select`
- `tests/*` ignores `S101` (pytest requires `assert`)
- `tools/*` ignores `S603`/`S607` (intentional subprocess in debug scripts)

## Verification
- `uvx ruff check --select S .` → 0 violations
- Production `bentolab/` source: 0 S-rule violations

## Follow-up
- `tools/*` still ignores `C901` for 9 functions exceeding complexity 10. Refactor planned after motion profiles land.

Part of an org-wide Ruff-S rollout across lambda/, qte77/, RDI/ repos.